### PR TITLE
Include lib in jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See developer site for more details.
 ## Build .jar file
 
     $ cd kintone-sdk
-    $ mvn clean compile jar:jar
+    $ mvn clean compile assembly:single
 
 ## Release Notes
 

--- a/kintone-sdk/pom.xml
+++ b/kintone-sdk/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.3.1</version>
+      <version>2.8.2</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/kintone-sdk/pom.xml
+++ b/kintone-sdk/pom.xml
@@ -25,4 +25,17 @@
   <properties>
     <skipTests>true</skipTests>
   </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
外部ライブラリとしてjarを使用したら、
jarにgsonが含まれておらず実行時エラーになったので、
jarに含めるようにしました
